### PR TITLE
fix: es6 default export & export TS definitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,4 +58,7 @@ const creator = (options, callback) => {
 };
 
 exports = module.exports = creator;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 export default creator;

--- a/src/index.js
+++ b/src/index.js
@@ -57,5 +57,5 @@ const creator = (options, callback) => {
   }
 };
 
-module.exports = creator;
+exports = module.exports = creator;
 export default creator;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,11 +33,14 @@ interface Options<T> {
   valueRenderer?: ValueRenderer<T>
 }
 
-declare function creator<T> (options: Options<T>): Promise<ResolvedValue<T>>;
-declare function creator<T> (options: Options<T>, callback: Callback<T>): void;
+type creatorPromise = <T> (options: Options<T>) => Promise<ResolvedValue<T>>;
+type creatorCallback = <T> (options: Options<T>, callback: Callback<T>) => void;
+type creator = creatorPromise & creatorCallback;
 
-export default creator
-
-declare module 'cli-select' {
-  export = creator
+interface creatorStatic {
+  default: creator
 }
+
+declare const cliSelect: creator & creatorStatic;
+
+export = cliSelect;


### PR DESCRIPTION
1) **Fixes es6 default export:**

Before, the export generated code would be:
```js
module.exports = creator;
var _default = creator;
exports.default = _default;
```
where `module.exports` is overridden and `exports.default` is assigned to an orphan object.

Now `module.exports` and `exports` are the same object (`creator`), thus the `.default` assignment works as expected:

But by reassigning `module.exports` and/or `exports` we break the commonjs interpo. flag `__esModule` (which is usually generated at the top of the file) so we have to manually add it back.
```js
exports = module.exports = creator;
Object.defineProperty(exports, "__esModule", {
  value: true
});
var _default = creator;
exports.default = _default;
```
Mixing commonJS and mjs exporting is usually not recommended.
___
2) **Fixes TS export definitions**

I don't know exactly when this change occurred, but now TS disallows the use of `export default|type|interface|const`  in the same file as `export =`