### PR TITLE
+ removed listener when stream closes

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -102,6 +102,8 @@ export default class Input {
     } else {
       this.onSelectListener(this.selectedValue, this.values[this.selectedValue]);
     }
+
+    this.stream.removeListener('keypress', this.onKeyPress);
   }
 
   /**


### PR DESCRIPTION
In most scenarios I expect people would use cli-select as part of a command line based apps where an option is chosen, something is performed, then the app exits back to the terminal and garbage collection would naturally occur when the process is killed. 

I have a scenario where I run cliOptions in a loop until cliSelect is exited.. a convenience tool around a number of common development activities (fabric commands) I perform regularly and can't be bothered to type out each time :).

```
function showOptions()
{
	
	cliSelect(options, (value) => {
		// console.log(value);
		
		if (value.id !== null) {
				console.log('selected ' + value.name + ': ' + value);
				showOptions();
		} else {
				// console.log('cancelled');
		}
	});
}

showOptions();
```

Each time the loop runs, because the keypress event listener is not removed when the stream is closed, more listeners are added. the callback count increases each time i select an option and eventually (after about 4 or 5) the maximum event stack is reached.

I've ensured the event handler is removed when after onSelectListener is called allowing cliSelect to be used as i've demonstrated until an exit condition

